### PR TITLE
pluto would not start without USE_DNSSEC=false

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN sed -i "s/httpredir\.debian\.org/ftp.us.debian.org/g" /etc/apt/sources.list 
     && rm -f "libreswan.tar.gz" \
     && cd "libreswan-${SWAN_VER}" \
     && echo "WERROR_CFLAGS =" > Makefile.inc.local \
+    && echo "USE_DNSSEC=false =" >> Makefile.inc.local \
     && make -s programs \
     && make -s install \
     && cd /opt/src \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -199,5 +199,5 @@ rm -f /var/run/pluto/pluto.pid /var/run/xl2tpd.pid
 
 [ -f /pre-up.sh ] && /pre-up.sh
 
-/usr/local/sbin/ipsec start --config /etc/ipsec.conf
+/usr/local/sbin/ipsec start
 exec /usr/sbin/xl2tpd -D -c /etc/xl2tpd/xl2tpd.conf


### PR DESCRIPTION
--config is no longer a valid parameter to 'ipsec start'